### PR TITLE
Canvas 시험 화면내 서술형 답안 제출시에 사용하는 tinymce 초기 설정에 paste_preprocess event 추가함

### DIFF
--- a/public/javascripts/tinymce.config.js
+++ b/public/javascripts/tinymce.config.js
@@ -76,6 +76,7 @@ export default class EditorConfig {
           ? 'hr,fullscreen,instructure-ui-icons,instructure_condensed_buttons,instructure_documents,instructure_html_view,instructure_media_embed'
           : 'textcolor'
       },link,directionality,a11y_checker,wordcount`,
+      paste_preprocess: (pl,ev) => {return this.preventPaste(pl,ev)},
       external_plugins: {
         instructure_image: '/javascripts/tinymce_plugins/instructure_image/plugin.js',
         instructure_links: '/javascripts/tinymce_plugins/instructure_links/plugin.js',
@@ -240,5 +241,9 @@ export default class EditorConfig {
   toolbar() {
     const instructure_buttons = this.buildInstructureButtons()
     return this.balanceButtons(instructure_buttons)
+  }
+
+  preventPaste(plugin,event) {
+    event.content = ''
   }
 }


### PR DESCRIPTION
Canvas 시험 화면내 서술형 답안 제출시 tinymce를 호출하는데
이는 외부 스크립트로 제어할 수 없는 부분이라서
tinymce 설정내에 붙여넣기시에 붙여넣을 내용을 초기화하는 함수를 추가해줌.
(적용하려면 캔버스 빌드 필요)

관련 wiki : https://xinics.atlassian.net/wiki/spaces/CCP/pages/2844950588/XLearn