### PR TITLE
PTT3-360 PDF 주석 첨삭기 열리도록 수정

### DIFF
--- a/app/controllers/file_previews_controller.rb
+++ b/app/controllers/file_previews_controller.rb
@@ -35,7 +35,7 @@ class FilePreviewsController < ApplicationController
     end
     if authorized_action(@file, @current_user, :read)
       url_opts = {
-        enable_annotations: params[:annotate].to_i != 0,
+        enable_annotations: false,
         course_id: params[:course_id],
         request_fullpath: request.fullpath
       }

--- a/app/controllers/file_previews_controller.rb
+++ b/app/controllers/file_previews_controller.rb
@@ -37,7 +37,8 @@ class FilePreviewsController < ApplicationController
       url_opts = {
         enable_annotations: false,
         course_id: params[:course_id],
-        request_fullpath: request.fullpath
+        request_fullpath: request.fullpath,
+        request_referer: request.referer
       }
       if url_opts[:enable_annotations]
         course = Course.find_by(id: params[:course_id].to_i)

--- a/app/controllers/file_previews_controller.rb
+++ b/app/controllers/file_previews_controller.rb
@@ -37,8 +37,7 @@ class FilePreviewsController < ApplicationController
       url_opts = {
         enable_annotations: false,
         course_id: params[:course_id],
-        request_fullpath: request.fullpath,
-        request_referer: request.referer
+        request_fullpath: request.fullpath
       }
       if url_opts[:enable_annotations]
         course = Course.find_by(id: params[:course_id].to_i)

--- a/app/controllers/file_previews_controller.rb
+++ b/app/controllers/file_previews_controller.rb
@@ -17,6 +17,7 @@
 
 class FilePreviewsController < ApplicationController
   include AttachmentHelper
+  include CanvadocsHelper
 
   before_action :get_context
 
@@ -33,6 +34,15 @@ class FilePreviewsController < ApplicationController
         formats: [:html]
     end
     if authorized_action(@file, @current_user, :read)
+      url_opts = {
+        enable_annotations: params[:annotate].to_i != 0,
+        course_id: params[:course_id],
+        request_fullpath: request.fullpath
+      }
+      if url_opts[:enable_annotations]
+        course = Course.find_by(id: params[:course_id].to_i)
+        url_opts[:enrollment_type] = canvadocs_user_role(course, @current_user)
+      end
       unless @file.grants_right?(@current_user, session, :download)
         @lock_info = @file.locked_for?(@current_user)
         return render template: 'file_previews/lock_explanation', layout: false
@@ -45,7 +55,7 @@ class FilePreviewsController < ApplicationController
       if Canvas::Plugin.value_to_boolean(params[:annotate]) && (url = @file.crocodoc_url(@current_user))
         redirect_to url and return
       # canvadocs
-      elsif url = @file.canvadoc_url(@current_user)
+      elsif url = @file.canvadoc_url(@current_user, url_opts)
         redirect_to url and return
       # google docs
       elsif GoogleDocsPreview.previewable?(@domain_root_account, @file)

--- a/app/controllers/gradebooks_controller.rb
+++ b/app/controllers/gradebooks_controller.rb
@@ -983,7 +983,7 @@ class GradebooksController < ApplicationController
           @current_user,
           avatars: service_enabled?(:avatars),
           grading_role: grading_role(assignment: @assignment)
-        ).json
+        ).json(request_fullpath: request.fullpath)
       end
     end
   end

--- a/app/controllers/gradebooks_controller.rb
+++ b/app/controllers/gradebooks_controller.rb
@@ -983,7 +983,7 @@ class GradebooksController < ApplicationController
           @current_user,
           avatars: service_enabled?(:avatars),
           grading_role: grading_role(assignment: @assignment)
-        ).json(request_fullpath: request.fullpath, request_referer: request.referer)
+        ).json(request_fullpath: request.fullpath)
       end
     end
   end

--- a/app/controllers/gradebooks_controller.rb
+++ b/app/controllers/gradebooks_controller.rb
@@ -983,7 +983,7 @@ class GradebooksController < ApplicationController
           @current_user,
           avatars: service_enabled?(:avatars),
           grading_role: grading_role(assignment: @assignment)
-        ).json(request_fullpath: request.fullpath)
+        ).json(request_fullpath: request.fullpath, request_referer: request.referer)
       end
     end
   end

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -26,7 +26,7 @@ module AttachmentHelper
       enable_annotations: attrs.delete(:enable_annotations),
       moderated_grading_allow_list: attrs[:moderated_grading_allow_list],
       submission_id: attrs.delete(:submission_id),
-      course_id: Course.find_by(id: params[:course_id].to_i).id,
+      course_id: params[:course_id].to_i,
       request_fullpath: request.fullpath
     }
     url_opts[:enrollment_type] = attrs.delete(:enrollment_type) if url_opts[:enable_annotations]

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -27,8 +27,7 @@ module AttachmentHelper
       moderated_grading_allow_list: attrs[:moderated_grading_allow_list],
       submission_id: attrs.delete(:submission_id),
       course_id: Course.find_by(id: params[:course_id].to_i).id,
-      request_fullpath: request.fullpath,
-      request_referer: request.referer
+      request_fullpath: request.fullpath
     }
     url_opts[:enrollment_type] = attrs.delete(:enrollment_type) if url_opts[:enable_annotations]
 

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -35,7 +35,7 @@ module AttachmentHelper
       rescue => e
         Canvas::Errors.capture_exception(:crocodoc, e)
       end
-    elsif attachment.canvadocable?
+    elsif attachment.custom_previewable? || attachment.canvadocable?
       attrs[:canvadoc_session_url] = attachment.canvadoc_url(@current_user, url_opts)
     end
     attrs[:attachment_id] = attachment.id

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -25,7 +25,9 @@ module AttachmentHelper
       anonymous_instructor_annotations: attrs.delete(:anonymous_instructor_annotations),
       enable_annotations: attrs.delete(:enable_annotations),
       moderated_grading_allow_list: attrs[:moderated_grading_allow_list],
-      submission_id: attrs.delete(:submission_id)
+      submission_id: attrs.delete(:submission_id),
+      course_id: Course.find_by(id: params[:course_id].to_i).id,
+      request_fullpath: request.fullpath
     }
     url_opts[:enrollment_type] = attrs.delete(:enrollment_type) if url_opts[:enable_annotations]
 

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -27,7 +27,8 @@ module AttachmentHelper
       moderated_grading_allow_list: attrs[:moderated_grading_allow_list],
       submission_id: attrs.delete(:submission_id),
       course_id: Course.find_by(id: params[:course_id].to_i).id,
-      request_fullpath: request.fullpath
+      request_fullpath: request.fullpath,
+      request_referer: request.referer
     }
     url_opts[:enrollment_type] = attrs.delete(:enrollment_type) if url_opts[:enable_annotations]
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1672,14 +1672,12 @@ class Attachment < ActiveRecord::Base
     custom_preview_base_url + ERB::Util.url_encode(public_download_url)
   end
 
-  def pdf_comment_editorable?(request_fullpath, request_referer)
+  def pdf_comment_editorable?(request_fullpath)
     return !$mobile_app &&
         request_fullpath.present? &&
-        request_referer.present? &&
         pdf_comment_editor_base_url.present? &&
         pdf_comment_editor_mime_types.include?(content_type) &&
-        pdf_comment_editor_use_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) } &&
-        pdf_comment_editor_use_referers.any? { |url_reg_exp| request_referer.match(url_reg_exp) }
+        pdf_comment_editor_use_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) }
   end
 
   def pdf_comment_editor_mime_types
@@ -1688,10 +1686,6 @@ class Attachment < ActiveRecord::Base
 
   def pdf_comment_editor_use_paths
     JSON.parse Setting.get('xn_pdf_comment_editor_use_paths', '[]')
-  end
-
-  def pdf_comment_editor_use_referers
-    JSON.parse Setting.get('xn_pdf_comment_editor_use_referers', '[]')
   end
 
   def pdf_comment_editor_launch_token(user, opts={})
@@ -2087,7 +2081,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def canvadoc_url(user, opts={})
-    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath], opts[:request_referer])
+    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath])
     return custom_preview_url if custom_previewable?
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1674,11 +1674,11 @@ class Attachment < ActiveRecord::Base
 
   def pdf_comment_editorable?(opts = {})
     return !$mobile_app &&
-        opts[:course_id].present? &&
-        opts[:request_fullpath].present? &&
-        pdf_comment_editor_base_url.present? &&
-        pdf_comment_editor_mime_types.include?(content_type) &&
-        pdf_comment_editor_use_paths.any? { |url_reg_exp| opts[:request_fullpath].match(url_reg_exp) }
+      opts[:course_id].present? &&
+      opts[:request_fullpath].present? &&
+      pdf_comment_editor_base_url.present? &&
+      pdf_comment_editor_mime_types.include?(content_type) &&
+      pdf_comment_editor_use_paths.any? { |url_reg_exp| opts[:request_fullpath].match(url_reg_exp) }
   end
 
   def pdf_comment_editor_mime_types
@@ -1691,16 +1691,16 @@ class Attachment < ActiveRecord::Base
 
   def pdf_comment_editor_launch_token(user, opts={})
     payload = {
-        iat: Time.now.to_i,
-        locale: pdf_comment_editor_locale,
-        course_id: opts[:course_id],
-        attachment_id: id,
-        file_url: public_download_url,
-        file_name: display_name,
-        user_name: user.name,
-        user_email: user.email,
-        user_role: enrollment_type_to_pdf_comment_editor_role(opts[:enrollment_type]),
-        readonly: opts[:enable_annotations].nil? || opts[:enable_annotations] === false
+      iat: Time.now.to_i,
+      locale: pdf_comment_editor_locale,
+      course_id: opts[:course_id],
+      attachment_id: id,
+      file_url: public_download_url,
+      file_name: display_name,
+      user_name: user.name,
+      user_email: user.email,
+      user_role: enrollment_type_to_pdf_comment_editor_role(opts[:enrollment_type]),
+      readonly: opts[:enable_annotations].nil? || opts[:enable_annotations] === false
     }
     token = JWT.encode(payload, pdf_comment_editor_jwt_secret, 'HS256', { typ: 'JWT' })
     return token
@@ -1709,30 +1709,30 @@ class Attachment < ActiveRecord::Base
   def pdf_comment_editor_locale
     case I18n.locale
     when :ko
-        return 'ko-KR'
+      return 'ko-KR'
     when :en
-        return 'en-US'
+      return 'en-US'
     when :ja
-        return 'ja-JP'
+      return 'ja-JP'
     else
-        return 'en-US'
+      return 'en-US'
     end
   end
 
   def enrollment_type_to_pdf_comment_editor_role(enrollment_type)
     case enrollment_type
     when 'student'
-        return 0
+      return 0
     when 'teacher'
-        return 1
+      return 1
     when 'ta'
-        return 2
+      return 2
     when 'designer'
-        return 3
+      return 3
     when 'observer'
-        return 4
+      return 4
     else
-        return 0
+      return 0
     end
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1672,12 +1672,13 @@ class Attachment < ActiveRecord::Base
     custom_preview_base_url + ERB::Util.url_encode(public_download_url)
   end
 
-  def pdf_comment_editorable?(request_fullpath)
+  def pdf_comment_editorable?(opts = {})
     return !$mobile_app &&
-        request_fullpath.present? &&
+        opts[:course_id].present? &&
+        opts[:request_fullpath].present? &&
         pdf_comment_editor_base_url.present? &&
         pdf_comment_editor_mime_types.include?(content_type) &&
-        pdf_comment_editor_use_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) }
+        pdf_comment_editor_use_paths.any? { |url_reg_exp| opts[:request_fullpath].match(url_reg_exp) }
   end
 
   def pdf_comment_editor_mime_types
@@ -2081,7 +2082,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def canvadoc_url(user, opts={})
-    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath])
+    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts)
     return custom_preview_url if custom_previewable?
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1672,6 +1672,77 @@ class Attachment < ActiveRecord::Base
     custom_preview_base_url + ERB::Util.url_encode(public_download_url)
   end
 
+  def pdf_comment_editorable?(request_fullpath)
+    return !$mobile_app && pdf_comment_editor_base_url.present? && request_fullpath.present? && pdf_comment_editor_mime_types.include?(content_type) && !pdf_comment_editor_exclude_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) }
+  end
+
+  def pdf_comment_editor_mime_types
+    JSON.parse Setting.get('xn_pdf_comment_editor_mime_types', '[]')
+  end
+
+  def pdf_comment_editor_exclude_paths
+    return JSON.parse Setting.get('xn_pdf_comment_editor_exclude_paths', '[]')
+  end
+
+  def pdf_comment_editor_launch_token(user, opts={})
+    payload = {
+        iat: Time.now.to_i,
+        locale: pdf_comment_editor_locale,
+        course_id: opts[:course_id],
+        attachment_id: id,
+        file_url: public_download_url,
+        file_name: display_name,
+        user_name: user.name,
+        user_email: user.email,
+        user_role: enrollment_type_to_pdf_comment_editor_role(opts[:enrollment_type]),
+        readonly: opts[:enable_annotations].nil? || opts[:enable_annotations] === false
+    }
+    token = JWT.encode(payload, pdf_comment_editor_jwt_secret, 'HS256', { typ: 'JWT' })
+    return token
+  end
+
+  def pdf_comment_editor_locale
+    case I18n.locale
+    when :ko
+        return 'ko-KR'
+    when :en
+        return 'en-US'
+    when :ja
+        return 'ja-JP'
+    else
+        return 'en-US'
+    end
+  end
+
+  def enrollment_type_to_pdf_comment_editor_role(enrollment_type)
+    case enrollment_type
+    when 'student'
+        return 0
+    when 'teacher'
+        return 1
+    when 'ta'
+        return 2
+    when 'designer'
+        return 3
+    when 'observer'
+        return 4
+    else
+        return 0
+    end
+  end
+
+  def pdf_comment_editor_jwt_secret
+    return Setting.get('xn_pdf_comment_editor_jwt_secret', nil)
+  end
+
+  def pdf_comment_editor_url(user, opts={})
+    return pdf_comment_editor_base_url + pdf_comment_editor_launch_token(user, opts)
+  end
+
+  def pdf_comment_editor_base_url
+    return Setting.get('xn_pdf_comment_editor_base_url', nil)
+  end
+
   def self.submit_to_canvadocs(ids)
     Attachment.where(id: ids).find_each do |a|
       a.submit_to_canvadocs
@@ -2006,6 +2077,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def canvadoc_url(user, opts={})
+    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath])
     return custom_preview_url if custom_previewable?
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1672,16 +1672,26 @@ class Attachment < ActiveRecord::Base
     custom_preview_base_url + ERB::Util.url_encode(public_download_url)
   end
 
-  def pdf_comment_editorable?(request_fullpath)
-    return !$mobile_app && pdf_comment_editor_base_url.present? && request_fullpath.present? && pdf_comment_editor_mime_types.include?(content_type) && !pdf_comment_editor_exclude_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) }
+  def pdf_comment_editorable?(request_fullpath, request_referer)
+    return !$mobile_app &&
+        request_fullpath.present? &&
+        request_referer.present? &&
+        pdf_comment_editor_base_url.present? &&
+        pdf_comment_editor_mime_types.include?(content_type) &&
+        pdf_comment_editor_use_paths.any? { |url_reg_exp| request_fullpath.match(url_reg_exp) } &&
+        pdf_comment_editor_use_referers.any? { |url_reg_exp| request_referer.match(url_reg_exp) }
   end
 
   def pdf_comment_editor_mime_types
     JSON.parse Setting.get('xn_pdf_comment_editor_mime_types', '[]')
   end
 
-  def pdf_comment_editor_exclude_paths
-    return JSON.parse Setting.get('xn_pdf_comment_editor_exclude_paths', '[]')
+  def pdf_comment_editor_use_paths
+    JSON.parse Setting.get('xn_pdf_comment_editor_use_paths', '[]')
+  end
+
+  def pdf_comment_editor_use_referers
+    JSON.parse Setting.get('xn_pdf_comment_editor_use_referers', '[]')
   end
 
   def pdf_comment_editor_launch_token(user, opts={})
@@ -2077,7 +2087,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def canvadoc_url(user, opts={})
-    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath])
+    return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts[:request_fullpath], opts[:request_referer])
     return custom_preview_url if custom_previewable?
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"

--- a/app/models/speed_grader/assignment.rb
+++ b/app/models/speed_grader/assignment.rb
@@ -33,7 +33,7 @@ module SpeedGrader
       @grading_role = grading_role
     end
 
-    def json(request_fullpath: '', request_referer: '')
+    def json(request_fullpath: '')
       Attachment.skip_thumbnails = true
       submission_json_fields = %i(id submitted_at workflow_state grade
                                   grade_matches_current_submission graded_at turnitin_data
@@ -206,8 +206,7 @@ module SpeedGrader
           ),
           submission_id: sub.id,
           course_id: course.id,
-          request_fullpath: request_fullpath,
-          request_referer: request_referer
+          request_fullpath: request_fullpath
         }
 
         if url_opts[:enable_annotations]

--- a/app/models/speed_grader/assignment.rb
+++ b/app/models/speed_grader/assignment.rb
@@ -33,7 +33,7 @@ module SpeedGrader
       @grading_role = grading_role
     end
 
-    def json
+    def json(request_fullpath: '')
       Attachment.skip_thumbnails = true
       submission_json_fields = %i(id submitted_at workflow_state grade
                                   grade_matches_current_submission graded_at turnitin_data
@@ -204,7 +204,9 @@ module SpeedGrader
             current_user,
             loaded_attachments: attachments_for_submission[sub]
           ),
-          submission_id: sub.id
+          submission_id: sub.id,
+          course_id: course.id,
+          request_fullpath: request_fullpath
         }
 
         if url_opts[:enable_annotations]

--- a/app/models/speed_grader/assignment.rb
+++ b/app/models/speed_grader/assignment.rb
@@ -33,7 +33,7 @@ module SpeedGrader
       @grading_role = grading_role
     end
 
-    def json(request_fullpath: '')
+    def json(request_fullpath: '', request_referer: '')
       Attachment.skip_thumbnails = true
       submission_json_fields = %i(id submitted_at workflow_state grade
                                   grade_matches_current_submission graded_at turnitin_data
@@ -206,7 +206,8 @@ module SpeedGrader
           ),
           submission_id: sub.id,
           course_id: course.id,
-          request_fullpath: request_fullpath
+          request_fullpath: request_fullpath,
+          request_referer: request_referer
         }
 
         if url_opts[:enable_annotations]

--- a/lib/api/v1/attachment.rb
+++ b/lib/api/v1/attachment.rb
@@ -135,7 +135,9 @@ module Api::V1::Attachment
         enable_annotations: options[:enable_annotations],
         enrollment_type: options[:enrollment_type],
         anonymous_instructor_annotations: options[:anonymous_instructor_annotations],
-        submission_id: options[:submission_id]
+        submission_id: options[:submission_id],
+        course_id: options[:course_id],
+        request_fullpath: options[:request_fullpath]
       }
       hash['preview_url'] = attachment.crocodoc_url(user, url_opts) ||
                             attachment.canvadoc_url(user, url_opts)


### PR DESCRIPTION
### 수정사항 요약
- SpeedGrader에서 PDF 파일인 경우 PDF 주석 첨삭기가 열리도록 함
- 제출물 상세정보에서 PDF 주석 첨삭기가 열릴 수 있도록 함
- 모듈에서 파일 미리보기 시 사이냅뷰어가 열리도록 함

<html>
<body>
<!--StartFragment--><google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->

메뉴 | 기존 | 수정 후
-- | -- | --
과제 및 평가 > 과제 선택 > SpeedGrader | Synap Viewer, Google Docs | PDF 주석 첨삭기, Synap Viewer, Google Docs
과제 및 평가 > 과제 선택 > 제출물 세부정보 > 주석첨삭 보기 | (없음) | PDF 주석 첨삭기
파일 메뉴 > 파일탐색기 > 파일 선택 | Synap Viewer, Google Docs | Synap Viewer, Google Docs
모듈 메뉴 > 모듈 > 파일 선택 | Google Docs | Synap Viewer, Google Docs

<!--EndFragment-->
</body>
</html>

### 수정된 API
- `/api/v1/files/:file_id` -> 제출물 상세정보 페이지에서 사용
- `/courses/:course_id/gradebook/speed_grader.json` -> SpeedGrader에서 사용
- `/courses/:course_id/files/:file_id/file_preview` -> 파일 메뉴 > 파일탐색기에서 사용
- `/courses/104/files/461?module_item_id=` -> 모듈에서 사용

### 설정 값
`secret-key` 치환 필요
```
cd /data/canvas
sudo -u canvas RAILS_ENV=production bundle exec rails console; sudo -u canvas bin/spring stop

Setting.set('xn_pdf_comment_editor_jwt_secret', 'secret-key')
Setting.set('xn_pdf_comment_editor_base_url', '/pdf-comment-editor/launch.php?token=')
Setting.set('xn_pdf_comment_editor_mime_types', %w[
    application/pdf
    application/haansoftpdf
    pdf
].to_json)
Setting.set('xn_pdf_comment_editor_use_paths', %w[
   \/courses\/\d+\/gradebook\/speed_grader.json
   \/api\/v1\/files\/\d+
].to_json)
```

### 관련된 커밋
bitbucket xlearn repository commit 48042a67f9c7ff2a1cc9ee8a16d67ee9ad04b1b9 (custom.js 수정)

### PR 하기 전 한 것
로컬 개발 VM에서 테스트 진행 완료

### PR merge 후 할 것
canvas-20201202에 적용 예정(? 해당 작업은 확인 필요)