### PR TITLE
Fix: PTT3-410 사이냅뷰어 + PDF 주석 첨삭기 관련 설정 가져올 때 캐시 무시하도록 함

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1660,11 +1660,11 @@ class Attachment < ActiveRecord::Base
   end
 
   def custom_preview_base_url
-    Setting.get('xn_custom_preview_base_url', nil)
+    Setting.skip_cache { Setting.get('xn_custom_preview_base_url', nil) }
   end
 
   def custom_previewable_mime_types
-    JSON.parse Setting.get('xn_custom_previewable_mime_types', '[]')
+    JSON.parse Setting.skip_cache { Setting.get('xn_custom_previewable_mime_types', '[]') }
   end
 
   def custom_preview_url
@@ -1682,11 +1682,11 @@ class Attachment < ActiveRecord::Base
   end
 
   def pdf_comment_editor_mime_types
-    JSON.parse Setting.get('xn_pdf_comment_editor_mime_types', '[]')
+    JSON.parse Setting.skip_cache { Setting.get('xn_pdf_comment_editor_mime_types', '[]') }
   end
 
   def pdf_comment_editor_use_paths
-    JSON.parse Setting.get('xn_pdf_comment_editor_use_paths', '[]')
+    JSON.parse Setting.skip_cache { Setting.get('xn_pdf_comment_editor_use_paths', '[]') }
   end
 
   def pdf_comment_editor_launch_token(user, opts={})
@@ -1737,7 +1737,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def pdf_comment_editor_jwt_secret
-    return Setting.get('xn_pdf_comment_editor_jwt_secret', nil)
+    return Setting.skip_cache { Setting.get('xn_pdf_comment_editor_jwt_secret', nil) }
   end
 
   def pdf_comment_editor_url(user, opts={})
@@ -1745,7 +1745,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def pdf_comment_editor_base_url
-    return Setting.get('xn_pdf_comment_editor_base_url', nil)
+    return Setting.skip_cache { Setting.get('xn_pdf_comment_editor_base_url', nil) }
   end
 
   def self.submit_to_canvadocs(ids)


### PR DESCRIPTION
- 설정 적용 후 다음날 아파치 리로드 시, 일부 패신저 프로세스에서 설정이 리셋되는 현상이 발견되었기 때문에 관련 설정들을 항상 캐시 무시하고 DB에서 가져오도록 수정하였다.