### PR TITLE
Fix: EXPRJ-960 사이냅뷰어, PDF 주석 첨삭기 미리보기가 풀리는 현상 해결

### DIFF
--- a/app/controllers/gradebooks_controller.rb
+++ b/app/controllers/gradebooks_controller.rb
@@ -983,7 +983,7 @@ class GradebooksController < ApplicationController
           @current_user,
           avatars: service_enabled?(:avatars),
           grading_role: grading_role(assignment: @assignment)
-        ).json(request_fullpath: request.fullpath)
+        ).json(request_fullpath: request.fullpath, mobile_app: !!(request.user_agent.to_s =~ /iosTeacher|LearningX( |%20)Teacher|iCanvas|LearningX( |%20)Student|androidTeacher|candroid/i))
       end
     end
   end

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -192,10 +192,6 @@
 #
 class SubmissionsApiController < ApplicationController
   before_action :get_course_from_section, :require_context, :require_user
-  before_action only: [:index] do
-    mobile_app = !!(request.user_agent.to_s =~ /iosTeacher|LearningX( |%20)Teacher|iCanvas|LearningX( |%20)Student|androidTeacher|candroid/i)
-    $mobile_app = mobile_app if mobile_app
-  end
   batch_jobs_in_actions :only => [:update], :batch => { :priority => Delayed::LOW_PRIORITY }
 
   include Api::V1::Progress

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1655,8 +1655,8 @@ class Attachment < ActiveRecord::Base
     Canvadocs.enabled? && canvadocable_mime_types.include?(content_type_with_text_match)
   end
 
-  def custom_previewable?
-    !$mobile_app && custom_preview_base_url.present? && custom_previewable_mime_types.include?(content_type)
+  def custom_previewable?(opts={})
+    !opts[:mobile_app] && custom_preview_base_url.present? && custom_previewable_mime_types.include?(content_type)
   end
 
   def custom_preview_base_url
@@ -1673,7 +1673,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def pdf_comment_editorable?(opts = {})
-    return !$mobile_app &&
+    return !opts[:mobile_app] &&
       opts[:course_id].present? &&
       opts[:request_fullpath].present? &&
       pdf_comment_editor_base_url.present? &&
@@ -2083,7 +2083,7 @@ class Attachment < ActiveRecord::Base
 
   def canvadoc_url(user, opts={})
     return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts)
-    return custom_preview_url if custom_previewable?
+    return custom_preview_url if custom_previewable?(opts)
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"
   end

--- a/app/models/speed_grader/assignment.rb
+++ b/app/models/speed_grader/assignment.rb
@@ -33,7 +33,7 @@ module SpeedGrader
       @grading_role = grading_role
     end
 
-    def json(request_fullpath: '')
+    def json(request_fullpath: '', mobile_app: false)
       Attachment.skip_thumbnails = true
       submission_json_fields = %i(id submitted_at workflow_state grade
                                   grade_matches_current_submission graded_at turnitin_data
@@ -206,7 +206,8 @@ module SpeedGrader
           ),
           submission_id: sub.id,
           course_id: course.id,
-          request_fullpath: request_fullpath
+          request_fullpath: request_fullpath,
+          mobile_app: mobile_app
         }
 
         if url_opts[:enable_annotations]


### PR DESCRIPTION
- 모바일로 과제 제출 확인 시 PC에서 사이냅뷰어, PDF 주석 첨삭기 미리보기가 풀리는 현상이 발견되었다.
- submissions_api_controller.rb에서 모바일 접근 여부 전역 변수인 $mobile_app를 설정하고 있는데, 모바일일 때만 true로 설정하고 false일 때는 설정하지 않는게 문제였다.
- 전역 변수로 전달하는 방식은 잠재 위험이 크므로 전역 변수를 제거하고 모바일 접근 여부를 전역 변수가 아닌 인자로 전달하도록 수정하여 해결하였다.