### PR TITLE
Fix: EXPRJ-960 모바일에서 미리보기 후 PC 사이냅뷰어, PDF 주석 첨삭기 미리보기가 풀리는 현상 수정

### DIFF
--- a/app/controllers/gradebooks_controller.rb
+++ b/app/controllers/gradebooks_controller.rb
@@ -983,7 +983,7 @@ class GradebooksController < ApplicationController
           @current_user,
           avatars: service_enabled?(:avatars),
           grading_role: grading_role(assignment: @assignment)
-        ).json(request_fullpath: request.fullpath)
+        ).json(request_fullpath: request.fullpath, mobile_app: !!(request.user_agent.to_s =~ /iosTeacher|LearningX( |%20)Teacher|iCanvas|LearningX( |%20)Student|androidTeacher|candroid/i))
       end
     end
   end

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -192,10 +192,6 @@
 #
 class SubmissionsApiController < ApplicationController
   before_action :get_course_from_section, :require_context, :require_user
-  before_action only: [:index] do
-    mobile_app = !!(request.user_agent.to_s =~ /iosTeacher|LearningX( |%20)Teacher|iCanvas|LearningX( |%20)Student|androidTeacher|candroid/i)
-    $mobile_app = mobile_app if mobile_app
-  end
   batch_jobs_in_actions :only => [:update], :batch => { :priority => Delayed::LOW_PRIORITY }
 
   include Api::V1::Progress

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -255,9 +255,15 @@ class SubmissionsApiController < ApplicationController
                                    polymorphic_url([:api_v1, @section || @context, @assignment, :submissions]))
         bulk_load_attachments_and_previews(submissions)
 
+        # iOS Teacher > 과제 및 평가 > 과제 선택 > 제출물에 접속하면 여기로 들어온다.
+        # 모바일에서 뷰어가 열리지 않는 것(모바일에선 사이냅뷰어가 안보인다)을 방지하기 위해 모바일 여부를 여기서 확인하고 인자로 canvadoc_url까지 전달한다.
+        # canvadoc_url은 lib/api/v1/attachment.rb#attachment_json에서 호출된다.
+        opts = {
+          mobile_app: !!(request.user_agent.to_s =~ /iosTeacher|LearningX( |%20)Teacher|iCanvas|LearningX( |%20)Student|androidTeacher|candroid/i)
+        }
         submissions.map do |s|
           s.visible_to_user = true
-          submission_json(s, @assignment, @current_user, session, @context, includes, params)
+          submission_json(s, @assignment, @current_user, session, @context, includes, params, opts: opts)
         end
       end
 

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -263,7 +263,7 @@ class SubmissionsApiController < ApplicationController
         }
         submissions.map do |s|
           s.visible_to_user = true
-          submission_json(s, @assignment, @current_user, session, @context, includes, params, opts: opts)
+          submission_json(s, @assignment, @current_user, session, @context, includes, params, false, opts)
         end
       end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1655,8 +1655,8 @@ class Attachment < ActiveRecord::Base
     Canvadocs.enabled? && canvadocable_mime_types.include?(content_type_with_text_match)
   end
 
-  def custom_previewable?
-    !$mobile_app && custom_preview_base_url.present? && custom_previewable_mime_types.include?(content_type)
+  def custom_previewable?(opts={})
+    !opts[:mobile_app] && custom_preview_base_url.present? && custom_previewable_mime_types.include?(content_type)
   end
 
   def custom_preview_base_url
@@ -1673,7 +1673,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def pdf_comment_editorable?(opts = {})
-    return !$mobile_app &&
+    return !opts[:mobile_app] &&
       opts[:course_id].present? &&
       opts[:request_fullpath].present? &&
       pdf_comment_editor_base_url.present? &&
@@ -2083,7 +2083,7 @@ class Attachment < ActiveRecord::Base
 
   def canvadoc_url(user, opts={})
     return pdf_comment_editor_url(user, opts) if pdf_comment_editorable?(opts)
-    return custom_preview_url if custom_previewable?
+    return custom_preview_url if custom_previewable?(opts)
     return unless canvadocable?
     "/api/v1/canvadoc_session?#{preview_params(user, 'canvadoc', opts)}"
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1668,7 +1668,6 @@ class Attachment < ActiveRecord::Base
   end
 
   def custom_preview_url
-    return unless custom_previewable?
     custom_preview_base_url + ERB::Util.url_encode(public_download_url)
   end
 

--- a/app/models/speed_grader/assignment.rb
+++ b/app/models/speed_grader/assignment.rb
@@ -33,7 +33,7 @@ module SpeedGrader
       @grading_role = grading_role
     end
 
-    def json(request_fullpath: '')
+    def json(request_fullpath: '', mobile_app: false)
       Attachment.skip_thumbnails = true
       submission_json_fields = %i(id submitted_at workflow_state grade
                                   grade_matches_current_submission graded_at turnitin_data
@@ -206,7 +206,8 @@ module SpeedGrader
           ),
           submission_id: sub.id,
           course_id: course.id,
-          request_fullpath: request_fullpath
+          request_fullpath: request_fullpath,
+          mobile_app: mobile_app
         }
 
         if url_opts[:enable_annotations]

--- a/lib/api/v1/attachment.rb
+++ b/lib/api/v1/attachment.rb
@@ -137,7 +137,8 @@ module Api::V1::Attachment
         anonymous_instructor_annotations: options[:anonymous_instructor_annotations],
         submission_id: options[:submission_id],
         course_id: options[:course_id],
-        request_fullpath: options[:request_fullpath]
+        request_fullpath: options[:request_fullpath],
+        mobile_app: options[:mobile_app]
       }
       hash['preview_url'] = attachment.crocodoc_url(user, url_opts) ||
                             attachment.canvadoc_url(user, url_opts)

--- a/lib/api/v1/submission.rb
+++ b/lib/api/v1/submission.rb
@@ -29,9 +29,9 @@ module Api::V1::Submission
   include Api::V1::RubricAssessment
   include CoursesHelper
 
-  def submission_json(submission, assignment, current_user, session, context = nil, includes = [], params = {}, avatars = false)
+  def submission_json(submission, assignment, current_user, session, context = nil, includes = [], params = {}, avatars = false, opts: {})
     context ||= assignment.context
-    hash = submission_attempt_json(submission, assignment, current_user, session, context, params)
+    hash = submission_attempt_json(submission, assignment, current_user, session, context, params, opts: opts)
 
     # The "body" attribute is intended to store the contents of text-entry
     # submissions, but for quizzes it contains a string that includes grading
@@ -54,7 +54,7 @@ module Api::V1::Submission
         end
         hash['submission_history'] = histories.map do |ver|
           ver.without_versioned_attachments do
-            submission_attempt_json(ver, assignment, current_user, session, context, params)
+            submission_attempt_json(ver, assignment, current_user, session, context, params, opts: opts)
           end
         end
       end
@@ -135,7 +135,7 @@ module Api::V1::Submission
   SUBMISSION_JSON_METHODS = %w(late missing seconds_late entered_grade entered_score).freeze
   SUBMISSION_OTHER_FIELDS = %w(attachments discussion_entries).freeze
 
-  def submission_attempt_json(attempt, assignment, user, session, context = nil, params = {}, quiz_submission_version = nil)
+  def submission_attempt_json(attempt, assignment, user, session, context = nil, params = {}, quiz_submission_version = nil, opts: {})
     context ||= assignment.context
     includes = Array.wrap(params[:include])
 
@@ -206,6 +206,7 @@ module Api::V1::Submission
           moderated_grading_allow_list: attempt.moderated_grading_allow_list(user),
           skip_permission_checks: true,
           submission_id: attempt.id
+          mobile_app: opts[:mobile_app]
         }
 
         attachment_json(attachment, user, {}, options)

--- a/lib/api/v1/submission.rb
+++ b/lib/api/v1/submission.rb
@@ -205,7 +205,7 @@ module Api::V1::Submission
           include: includes,
           moderated_grading_allow_list: attempt.moderated_grading_allow_list(user),
           skip_permission_checks: true,
-          submission_id: attempt.id
+          submission_id: attempt.id,
           mobile_app: opts[:mobile_app]
         }
 

--- a/lib/api/v1/submission.rb
+++ b/lib/api/v1/submission.rb
@@ -29,9 +29,9 @@ module Api::V1::Submission
   include Api::V1::RubricAssessment
   include CoursesHelper
 
-  def submission_json(submission, assignment, current_user, session, context = nil, includes = [], params = {}, avatars = false, opts: {})
+  def submission_json(submission, assignment, current_user, session, context = nil, includes = [], params = {}, avatars = false, opts = {})
     context ||= assignment.context
-    hash = submission_attempt_json(submission, assignment, current_user, session, context, params, opts: opts)
+    hash = submission_attempt_json(submission, assignment, current_user, session, context, params, nil, opts)
 
     # The "body" attribute is intended to store the contents of text-entry
     # submissions, but for quizzes it contains a string that includes grading
@@ -54,7 +54,7 @@ module Api::V1::Submission
         end
         hash['submission_history'] = histories.map do |ver|
           ver.without_versioned_attachments do
-            submission_attempt_json(ver, assignment, current_user, session, context, params, opts: opts)
+            submission_attempt_json(ver, assignment, current_user, session, context, params, nil, opts)
           end
         end
       end
@@ -135,7 +135,7 @@ module Api::V1::Submission
   SUBMISSION_JSON_METHODS = %w(late missing seconds_late entered_grade entered_score).freeze
   SUBMISSION_OTHER_FIELDS = %w(attachments discussion_entries).freeze
 
-  def submission_attempt_json(attempt, assignment, user, session, context = nil, params = {}, quiz_submission_version = nil, opts: {})
+  def submission_attempt_json(attempt, assignment, user, session, context = nil, params = {}, quiz_submission_version = nil, opts = {})
     context ||= assignment.context
     includes = Array.wrap(params[:include])
 
@@ -251,8 +251,8 @@ module Api::V1::Submission
     }
   end
 
-  def quiz_submission_attempt_json(attempt, assignment, user, session, context = nil, params)
-    hash = submission_attempt_json(attempt.submission, assignment, user, session, context, params, attempt.version_number)
+  def quiz_submission_attempt_json(attempt, assignment, user, session, context = nil, params = {}, opts = {})
+    hash = submission_attempt_json(attempt.submission, assignment, user, session, context, params, attempt.version_number, opts)
     hash.each_key{|k| hash[k] = attempt[k] if attempt[k]}
     hash[:submission_data] = attempt[:submission_data]
     hash[:submitted_at] = attempt[:finished_at]


### PR DESCRIPTION
- Fix: EXPRJ-960 사이냅뷰어, PDF 주석 첨삭기 미리보기가 풀리는 현상 해결
  - 모바일로 과제 제출 확인 시 PC에서 사이냅뷰어, PDF 주석 첨삭기 미리보기가 풀리는 현상이 발견되었다.
  - submissions_api_controller.rb에서 모바일 접근 여부 전역 변수인 $mobile_app를 설정하고 있는데, 모바일일 때만 true로 설정하고 false일 때는 설정하지 않는게 문제였다.
  - 전역 변수로 전달하는 방식은 잠재 위험이 크므로 전역 변수를 제거하고 모바일 접근 여부를 전역 변수가 아닌 인자로 전달하도록 수정하여 해결하였다.
- Fix: EXPRJ-960 iOS Teacher 환경에서는 과제 제출물 보기가 안되는 문제 수정
  -  iOS Teacher 앱에서는 여타 앱과는 달리 /api/v1/courses/2765/assignments/4192/submissions 경로로 미리보기 URL을 요청하기 때문에 모바일 여부 검사가 누락되어 검사하는 로직을 추가하였다.